### PR TITLE
JSS-83 Implement a service for executing strings as JavaScript code inside of JSS

### DIFF
--- a/JSSRepl/Application/Application.csproj
+++ b/JSSRepl/Application/Application.csproj
@@ -7,6 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="JSS" Version="24.5.18.130228" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Domain\Domain.csproj" />
   </ItemGroup>
 

--- a/JSSRepl/Application/Services/IJSSService.cs
+++ b/JSSRepl/Application/Services/IJSSService.cs
@@ -1,0 +1,16 @@
+﻿namespace Presentation.Server.Services;
+
+/// <summary>
+/// A service for executing strings as JavaScript using the JSS engine. <br/>
+/// An instance of this service contain a JSS VM that it will hold for its lifetime. <br/>
+/// This means any variables/functions defined will persist until a new instance is created.
+/// </summary>
+public interface IJSSService
+{
+    /// <summary>
+    /// Executes the provided string <paramref name="scriptCode"/> as JavaScript code in the JSS engine.
+    /// </summary>
+    /// <param name="script">The JavaScript script to be executed by JSS.</param>
+    /// <returns>A string that represents the result from executing the script.</returns>
+    public string ExecuteStringAsJavaScript(string scriptCode);
+}

--- a/JSSRepl/Application/Services/JSSService.cs
+++ b/JSSRepl/Application/Services/JSSService.cs
@@ -1,0 +1,52 @@
+﻿using JSS.Common;
+using JSS.Lib;
+using JSS.Lib.Execution;
+using Microsoft.Extensions.Logging;
+using SyntaxErrorException = JSS.Lib.SyntaxErrorException;
+
+namespace Presentation.Server.Services;
+
+/// <inheritdoc cref="IJSSService"/>
+public sealed class JSSService : IJSSService
+{
+    /// <summary>
+    /// Creates an instance of JSSService by creating the VM to be used for executing provided strings.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown if we failed to initialize the JSS VM.</exception>
+    public JSSService(ILogger<JSSService> logger)
+    {
+        _logger = logger;
+
+        var initializeResult = Realm.InitializeHostDefinedRealm(out _vm);
+        if (initializeResult.IsAbruptCompletion())
+        {
+            throw new InvalidOperationException($"Failed to initialize the JSS engine: {Print.CompletionToString(_vm, initializeResult)}.");
+        }
+    }
+
+    /// <inheritdoc/>
+    public string ExecuteStringAsJavaScript(string scriptCode)
+    {
+        _logger.LogInformation("{Script} was provided by user, attempting to execute.", scriptCode);
+
+        try
+        {
+            var parser = new Parser(scriptCode);
+            var script = parser.Parse(_vm);
+            var completion = script.ScriptEvaluation();
+            return Print.CompletionToString(_vm, completion);
+        }
+        catch (SyntaxErrorException ex)
+        {
+            return $"Uncaught {ex.Message}";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An unexpected exception was raised by JSS.");
+            return $"Internal Error! Reason: {ex}";
+        }
+    }
+
+    private readonly ILogger<JSSService> _logger;
+    private readonly VM _vm;
+}

--- a/JSSRepl/Presentation.Server/Program.cs
+++ b/JSSRepl/Presentation.Server/Program.cs
@@ -1,11 +1,14 @@
 using Serilog;
 using Presentation.Server.Components;
+using Presentation.Server.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents()
     .AddInteractiveWebAssemblyComponents();
+
+builder.Services.AddScoped<IJSSService, JSSService>();
 
 builder.Host.UseSerilog((ctx, cfg) => cfg.ReadFrom.Configuration(builder.Configuration));
 


### PR DESCRIPTION
We have implemented a service that allows for a string to be provided
and will be executed inside of JSS.

The service will hold the same JSS VM for its lifetime. This means that
any variables, functions etc. defined inside of the JSS engine will be
persisted.

We register the service as scoped as we want the user's code to persist
for a request, however, we don't want it shared between different
requests.