### PR TITLE
JSS-92 Display the build commit hash and commit link on JSSRepl

### DIFF
--- a/JSSRepl/Application/Application.csproj
+++ b/JSSRepl/Application/Application.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="JSS" Version="24.5.23.180801" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Octokit" Version="11.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/JSSRepl/Application/Installer.cs
+++ b/JSSRepl/Application/Installer.cs
@@ -1,0 +1,23 @@
+﻿using Application.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Octokit;
+
+namespace Application;
+
+public static class Installer
+{
+    public static IServiceCollection AddApplicationServices(this IServiceCollection services)
+    {
+        services.AddScoped<IJSSService, JSSService>();
+
+        services.AddTransient<IGitHubClient, GitHubClient>((_) => new GitHubClient(new ProductHeaderValue(JSSREPL_GITHUB_OWNER)));
+        services.AddTransient<IGitHubService, GitHubService>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// The GitHub user account ascociated with the JSSRepl repository
+    /// </summary>
+    const string JSSREPL_GITHUB_OWNER = "PrestonLTaylor";
+}

--- a/JSSRepl/Application/Services/GitHubService.cs
+++ b/JSSRepl/Application/Services/GitHubService.cs
@@ -1,0 +1,25 @@
+﻿using Octokit;
+
+namespace Application.Services;
+
+/// <inheritdoc cref="IGitHubService"/>
+public sealed class GitHubService : IGitHubService
+{
+    public GitHubService(IGitHubClient gitHubClient)
+    {
+        _gitHubClient = gitHubClient;
+    }
+
+    /// <inheritdoc/>
+    public async Task<GitHubCommit> GetLatestCommitAsync()
+    {
+        var branch = await _gitHubClient.Repository.Branch.Get(JSS_OWNER, JSS_REPO_NAME, JSS_MASTER_BRANCH);
+        return await _gitHubClient.Repository.Commit.Get(JSS_OWNER, JSS_REPO_NAME, branch.Commit.Sha);
+    }
+
+    const string JSS_OWNER = "PrestonLTaylor";
+    const string JSS_REPO_NAME = "JSS";
+    const string JSS_MASTER_BRANCH = "master";
+
+    private readonly IGitHubClient _gitHubClient;
+}

--- a/JSSRepl/Application/Services/IGitHubService.cs
+++ b/JSSRepl/Application/Services/IGitHubService.cs
@@ -1,0 +1,15 @@
+﻿using Octokit;
+
+namespace Application.Services;
+
+/// <summary>
+/// A service for retrieving commit information from the JSS GitHub repository.
+/// </summary>
+public interface IGitHubService
+{
+    /// <summary>
+    /// Retrieves information on the latest commit from the master branch.
+    /// </summary>
+    /// <returns>A task containing the latest commit from the master branch.</returns>
+    public Task<GitHubCommit> GetLatestCommitAsync();
+}

--- a/JSSRepl/Application/Services/IJSSService.cs
+++ b/JSSRepl/Application/Services/IJSSService.cs
@@ -1,4 +1,4 @@
-﻿namespace Presentation.Server.Services;
+﻿namespace Application.Services;
 
 /// <summary>
 /// A service for executing strings as JavaScript using the JSS engine. <br/>

--- a/JSSRepl/Application/Services/JSSService.cs
+++ b/JSSRepl/Application/Services/JSSService.cs
@@ -4,7 +4,7 @@ using JSS.Lib.Execution;
 using Microsoft.Extensions.Logging;
 using SyntaxErrorException = JSS.Lib.SyntaxErrorException;
 
-namespace Presentation.Server.Services;
+namespace Application.Services;
 
 /// <inheritdoc cref="IJSSService"/>
 public sealed class JSSService : IJSSService

--- a/JSSRepl/Presentation.Server/Components/Pages/Home.razor
+++ b/JSSRepl/Presentation.Server/Components/Pages/Home.razor
@@ -1,5 +1,6 @@
 ﻿@page "/"
 @inject IJSSService jss
+@inject IGitHubService github
 
 <PageTitle>JSS Repl</PageTitle>
 
@@ -11,15 +12,21 @@
 
         <button class="btn btn-outline-secondary execute-button" type="submit">Execute</button>
     </EditForm>
-    <small class="form-text text-muted">Executed using the JSS JavaScript engine.</small> <br/>
+    <small class="form-text text-muted">Executed using the JSS JavaScript engine (built from <a class="link-primary" href="@BuildCommitLink">@ShortBuildCommitHash</a>).</small> <br />
 
     <input type="text" class="form-control-plaintext" readonly value="@Result">
 </article>
 
 @code {
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         editContext = new(Script);
+
+        // NOTE: We use the latest commit hash from the master branch as that will be the commit used in the latest JSS NuGet package
+        // We also use dependabot so we can easily update the NuGet package so it will be up-to-date
+        var latestCommit = await github.GetLatestCommitAsync();
+        ShortBuildCommitHash = latestCommit.Sha[0..7];
+        BuildCommitLink = latestCommit.HtmlUrl;
     }
 
     private void Execute()
@@ -31,6 +38,9 @@
     private string Script { get; set; } = "";
 
     private string Result { get; set; } = "";
+
+    private string ShortBuildCommitHash { get; set; } = "";
+    private string BuildCommitLink { get; set; } = "";
 
     private EditContext? editContext;
 }

--- a/JSSRepl/Presentation.Server/Components/_Imports.razor
+++ b/JSSRepl/Presentation.Server/Components/_Imports.razor
@@ -6,7 +6,7 @@
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
+@using Application.Services
 @using Presentation.Server 
 @using Presentation.Client
 @using Presentation.Server.Components
-@using Presentation.Server.Services

--- a/JSSRepl/Presentation.Server/Program.cs
+++ b/JSSRepl/Presentation.Server/Program.cs
@@ -1,6 +1,6 @@
 using Serilog;
 using Presentation.Server.Components;
-using Presentation.Server.Services;
+using Application;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -8,7 +8,7 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents()
     .AddInteractiveWebAssemblyComponents();
 
-builder.Services.AddScoped<IJSSService, JSSService>();
+builder.Services.AddApplicationServices();
 
 builder.Host.UseSerilog((ctx, cfg) => cfg.ReadFrom.Configuration(builder.Configuration));
 


### PR DESCRIPTION
We now display the latest commit hash which is linked to the latest
commit on the master branch of JSS.

We use the latest commit hash as that is the commit of the latest NuGet
package (which is automatically uploading to NuGet). However, we do have
to manually merge the dependabot PRs for the JSS package updates.

We should try to automatically merge the PRs from dependabot for JSS
package updates.