### PR TITLE
JSS-99 Add a cache for the retrieving GitHub branch information

### DIFF
--- a/JSSRepl/Application/Application.csproj
+++ b/JSSRepl/Application/Application.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="JSS" Version="24.5.23.180801" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="Octokit" Version="11.0.1" />
   </ItemGroup>

--- a/JSSRepl/Application/Installer.cs
+++ b/JSSRepl/Application/Installer.cs
@@ -13,6 +13,8 @@ public static class Installer
         services.AddTransient<IGitHubClient, GitHubClient>((_) => new GitHubClient(new ProductHeaderValue(JSSREPL_GITHUB_OWNER)));
         services.AddTransient<IGitHubService, GitHubService>();
 
+        services.AddMemoryCache();
+
         return services;
     }
 

--- a/JSSRepl/Application/Services/GitHubService.cs
+++ b/JSSRepl/Application/Services/GitHubService.cs
@@ -1,17 +1,29 @@
-﻿using Octokit;
+﻿using Microsoft.Extensions.Caching.Memory;
+using Octokit;
 
 namespace Application.Services;
 
 /// <inheritdoc cref="IGitHubService"/>
 public sealed class GitHubService : IGitHubService
 {
-    public GitHubService(IGitHubClient gitHubClient)
+    public GitHubService(IGitHubClient gitHubClient, IMemoryCache cache)
     {
         _gitHubClient = gitHubClient;
+        _cache = cache;
     }
 
     /// <inheritdoc/>
-    public async Task<GitHubCommit> GetLatestCommitAsync()
+    public async Task<GitHubCommit> GetBuildCommitAsync()
+    {
+        return await _cache.GetOrCreateAsync(CACHE_KEY, async (entry) =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = CACHE_LIFETIME;
+            return await GetLatestCommitAsync();
+        })
+            ?? throw new InvalidOperationException("Failed to get GitHub commit of JSS build.");
+    }
+
+    private async Task<GitHubCommit> GetLatestCommitAsync()
     {
         var branch = await _gitHubClient.Repository.Branch.Get(JSS_OWNER, JSS_REPO_NAME, JSS_MASTER_BRANCH);
         return await _gitHubClient.Repository.Commit.Get(JSS_OWNER, JSS_REPO_NAME, branch.Commit.Sha);
@@ -20,6 +32,9 @@ public sealed class GitHubService : IGitHubService
     const string JSS_OWNER = "PrestonLTaylor";
     const string JSS_REPO_NAME = "JSS";
     const string JSS_MASTER_BRANCH = "master";
+    const string CACHE_KEY = "COMMIT_KEY";
+    private readonly TimeSpan CACHE_LIFETIME = TimeSpan.FromMinutes(30);
 
     private readonly IGitHubClient _gitHubClient;
+    private readonly IMemoryCache _cache;
 }

--- a/JSSRepl/Application/Services/IGitHubService.cs
+++ b/JSSRepl/Application/Services/IGitHubService.cs
@@ -11,5 +11,5 @@ public interface IGitHubService
     /// Retrieves information on the latest commit from the master branch.
     /// </summary>
     /// <returns>A task containing the latest commit from the master branch.</returns>
-    public Task<GitHubCommit> GetLatestCommitAsync();
+    public Task<GitHubCommit> GetBuildCommitAsync();
 }

--- a/JSSRepl/Presentation.Server/Components/Pages/Home.razor
+++ b/JSSRepl/Presentation.Server/Components/Pages/Home.razor
@@ -30,7 +30,7 @@
 
         // NOTE: We use the latest commit hash from the master branch as that will be the commit used in the latest JSS NuGet package
         // We also use dependabot so we can easily update the NuGet package so it will be up-to-date
-        var latestCommit = await github.GetLatestCommitAsync();
+        var latestCommit = await github.GetBuildCommitAsync();
         ShortBuildCommitHash = latestCommit.Sha[0..7];
         BuildCommitLink = latestCommit.HtmlUrl;
     }


### PR DESCRIPTION
We now have an in-memory for retrieving the branch information from the JSS repository.

The cache entry has a 30 minute lifetime so we should never run into any rate limitting issues with the GitHub API.